### PR TITLE
Fikser det build-warnings?

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -23,7 +23,7 @@ jobs:
           bundler-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
setup-python@v3 ændret til v4. Hvis det fjerner build warnings, skal den inkorporeres i styles. Og alle repos skal opdateres fra styles (suk)